### PR TITLE
Use symbol in obsolete variable sexp

### DIFF
--- a/memento-mori.el
+++ b/memento-mori.el
@@ -82,7 +82,7 @@ To use `memento-mori-mementos' customize it, or erase customization of
   :type 'string
   :group 'memento-mori)
 (make-obsolete-variable 'memento-mori-birth-date
-                        "memento-mori-mementos" "0.2.1")
+                        'memento-mori-mementos "0.2.1")
 
 (defcustom memento-mori-mementos
   '(("%y years since Harrison Bergeron was published"


### PR DESCRIPTION
This gives an improved warning message.

With this the following text from the docstring could be removed?

> This is deprecated in favor of the more flexible `memento-mori-mementos`.
To use `memento-mori-mementos` customize it, or erase customization of
`memento-mori-birth-date`.
