### PR TITLE
Fix adding to frame-title-format when it has been customized in certain ways

### DIFF
--- a/memento-mori.el
+++ b/memento-mori.el
@@ -432,12 +432,8 @@ org mode agenda, splash screen, etc."
           (and global-mode-string
                (delete memento-mori--modeline-construct global-mode-string))))
   (if memento-mori-display-in-frame-title
-      (if (stringp frame-title-format)
-          (setq frame-title-format
-                (list frame-title-format 'memento-mori--frame-title-construct))
-        (add-to-list 'frame-title-format
-                     'memento-mori--frame-title-construct
-                     t))
+      (setq frame-title-format
+            (list frame-title-format 'memento-mori--frame-title-construct))
     (when (listp frame-title-format)
       (setq frame-title-format
             (delete 'memento-mori--frame-title-construct frame-title-format)))))

--- a/memento-mori.el
+++ b/memento-mori.el
@@ -60,8 +60,8 @@ mode line it may not appear.
 
 If your mode line is already customized or the output provided by
 `memento-mori-display-in-modeline' isn't to your liking, you can add
-`memento-mori--modeline-construct' to `mode-line-format' manually
-instead of setting this variable."
+`memento-mori--modeline-info' to `mode-line-format' manually instead of
+setting this variable."
   :group 'memento-mori
   :type 'boolean
   :set #'memento-mori--set-value-and-update-display
@@ -72,7 +72,7 @@ instead of setting this variable."
 
 If your frame title is already customized or the output provided by
 `memento-mori-display-in-frame-title' isn't to your liking, you can add
-`memento-mori--frame-title-construct' to `frame-title-format' manually
+`memento-mori--frame-title-info' to `frame-title-format' manually
 instead of setting this variable."
   :group 'memento-mori
   :type 'boolean
@@ -282,7 +282,7 @@ Sets SYMBOL to VALUE, then calls updates `memento-mori--update'."
   (set-default-toplevel-value symbol value)
   (memento-mori--update))
 
-(defvar memento-mori--modeline-construct
+(defvar memento-mori--modeline-info
   `(memento-mori-mode
     ((:propertize
       ("" memento-mori-string)
@@ -297,7 +297,7 @@ See `mode-line-format' for information about the format.  It should
 append a space to the `memento-mori-string' which is considered best
 practice for inclusion in `global-mode-string'.")
 
-(defvar memento-mori--frame-title-construct
+(defvar memento-mori--frame-title-info
   `(memento-mori-mode
     (" -- " memento-mori-string))
   "A frame title construct to be added to `frame-title-format'.
@@ -437,16 +437,16 @@ org mode agenda, splash screen, etc."
   (if memento-mori-display-in-modeline
       ;; This assumes that global-mode-string is a list, even though technically
       ;; it could be a string
-      (add-to-list 'global-mode-string memento-mori--modeline-construct)
+      (add-to-list 'global-mode-string memento-mori--modeline-info)
     (setq global-mode-string
           (and global-mode-string
-               (delete memento-mori--modeline-construct global-mode-string))))
+               (delete memento-mori--modeline-info global-mode-string))))
   (if memento-mori-display-in-frame-title
       (setq frame-title-format
-            (list frame-title-format 'memento-mori--frame-title-construct))
+            (list frame-title-format 'memento-mori--frame-title-info))
     (when (listp frame-title-format)
       (setq frame-title-format
-            (delete 'memento-mori--frame-title-construct frame-title-format)))))
+            (delete 'memento-mori--frame-title-info frame-title-format)))))
 
 ;;;###autoload
 (define-minor-mode memento-mori-mode

--- a/memento-mori.el
+++ b/memento-mori.el
@@ -5,7 +5,7 @@
 ;; Author: Lassi Kortela <lassi@lassi.io>
 ;; Maintainer: Ivan Andrus <darthandrus@gmail.com>
 ;; URL: https://github.com/gvol/emacs-memento-mori
-;; Version: 0.3.1
+;; Version: 0.3.2
 ;; Package-Requires: ((emacs "24.4"))
 ;; Keywords: help
 ;; SPDX-License-Identifier: ISC

--- a/memento-mori.el
+++ b/memento-mori.el
@@ -56,14 +56,24 @@
   "If non-nil, `memento-mori-mode' will add mementos to the mode line.
 Really, it adds it to the `global-mode-string', which usually
 appears in the mode line, however, if you have customized your
-mode line it may not appear."
+mode line it may not appear.
+
+If your mode line is already customized or the output provided by
+`memento-mori-display-in-modeline' isn't to your liking, you can add
+`memento-mori--modeline-construct' to `mode-line-format' manually
+instead of setting this variable."
   :group 'memento-mori
   :type 'boolean
   :set #'memento-mori--set-value-and-update-display
   :initialize #'custom-initialize-default)
 
 (defcustom memento-mori-display-in-frame-title nil
-  "If non-nil, `memento-mori-mode' will add mementos to the frame title."
+  "If non-nil, `memento-mori-mode' will add mementos to the frame title.
+
+If your frame title is already customized or the output provided by
+`memento-mori-display-in-frame-title' isn't to your liking, you can add
+`memento-mori--frame-title-construct' to `frame-title-format' manually
+instead of setting this variable."
   :group 'memento-mori
   :type 'boolean
   :set #'memento-mori--set-value-and-update-display


### PR DESCRIPTION
The customization could be a single (:eval ...) construct, for example. There doesn't seem to be any problems nesting lists arbitrarily deep, though it may impact performance if it happened too much.

Fixes #20